### PR TITLE
Make title and slug of subpost unique

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "description": "AddMany is a TacoWordPress add-on that allows you to create an arbitrary number of fields for custom posts in the WordPress admin",
   "license": "proprietary",
   "minimum-stability": "dev",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "require": {
     "php": ">= 0.0.5"
   },

--- a/src/AddMany.php
+++ b/src/AddMany.php
@@ -106,7 +106,7 @@ class AddMany {
       return false;
     }
     $subpost = new \SubPost;
-    $subpost->set('post_title', 'subpost');
+    $subpost->set('post_title', 'AddMany subpost '.md5(mt_rand()));
     $subpost->set('post_parent', $post_data['parent_id']);
     $subpost->set(
       'field_assigned_to',


### PR DESCRIPTION
This prevents WordPress having to automatically append a number to each post slug, and makes the titles unique. When scanning the database, it also clarifies that those posts belong to AddMany.
