### PR TITLE
Update styles of result postboxes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "description": "AddMany is a TacoWordPress add-on that allows you to create an arbitrary number of fields for custom posts in the WordPress admin",
   "license": "proprietary",
   "minimum-stability": "dev",
-  "version": "0.1.2",
+  "version": "0.1.4",
   "require": {
     "php": ">= 0.0.5"
   },

--- a/src/Frontend/css/addmany.css
+++ b/src/Frontend/css/addmany.css
@@ -3,16 +3,14 @@
   clear: both;
   width: 100%;
   overflow-y: scroll;
-  -webkit-transition: all 100ms ease .4s;
-  -moz-transition: all 500ms ease .4s;
-  -o-transition: all 500ms ease .4s;
   transition: all 500ms ease .4s;
 }
 .addmany-result {
   cursor: pointer;
-  width: 95%;
+  box-sizing: border-box;
+  width: 100%;
   height: auto;
-  margin-bottom: 5px;
+  margin-bottom: 15px;
   padding-left: 10px;
   line-height: 27px;
   overflow: hidden;
@@ -25,16 +23,8 @@
   overflow-y: scroll;
 }
 .addmany-actual-values .addmany-result.postbox {
-  background-color: #F9F7F7;
-  -webkit-transition: background-color 500ms ease 1s;
-  -moz-transition: background-color 500ms ease 1s;
-  -o-transition: background-color 500ms ease 1s;
-  transition: background-color 500ms ease 1s;
-
-  -webkit-transition: color 500ms ease 1s;
-  -moz-transition: color 500ms ease 1s;
-  -o-transition: color 500ms ease 1s;
-  transition: color 500ms ease 1s;
+  background-color: #f9f9f9;
+  transition: background-color 500ms ease 1s, color 500ms ease 1s;
 }
 .addmany-actual-values .addmany-result.postbox.just-added {
   background-color: #0074a2;

--- a/src/Frontend/css/addmany.css
+++ b/src/Frontend/css/addmany.css
@@ -11,7 +11,7 @@
   width: 100%;
   height: auto;
   margin-bottom: 15px;
-  padding-left: 10px;
+  padding: 10px 50px 10px 10px;
   line-height: 27px;
   overflow: hidden;
 }
@@ -31,7 +31,9 @@
   color: #FFF;
 }
 .btn-addmany-delete {
-  float: right;
+  position: absolute;
+  right: 8px;
+  top: 8px;
 }
 .addmany ~ b {
   line-height: 40px;

--- a/src/Frontend/css/addmany.css
+++ b/src/Frontend/css/addmany.css
@@ -18,7 +18,6 @@
 .addmany-actual-values {
   clear: both;
   width: 100%;
-  min-height: 400px;
   height: auto;
   overflow-y: scroll;
 }

--- a/src/Frontend/js/addmany.js
+++ b/src/Frontend/js/addmany.js
@@ -299,7 +299,7 @@ define([
       post_title = (typeof post_title == 'undefined') ? '' : post_title;
       post_content = (typeof post_content == 'undefined') ? '' : post_content;
 
-      var html  = '<li style="height: auto!important; padding: 10px;" data-subpost-id="' + post_id + '" class="addmany-result postbox">';
+      var html  = '<li data-subpost-id="' + post_id + '" class="addmany-result postbox">';
           html += this.getDeleteButtonTemplate();
           html += '<input type="text" style="margin-bottom: 10px; width: 90%;" name="subposts['+ this.$this_object.attr('name') +'][' + post_id + '][post_title]" placeholder="title" value="' + post_title + '"><br>';
           html += '<textarea name="subposts[' + this.$this_object.attr('name') + '][' + post_id + '][post_content]" style="width: 90%;" placeholder="content">' + post_content +'</textarea>';
@@ -402,15 +402,10 @@ define([
     },
 
     getResultDefaultAttribs: function(post_id) {
-      var li_style = this.getStringFromObject({
-        height: 'auto !important',
-        padding: '10px'
-      });
       var li_classes = 'addmany-result postbox';
       return Taco.Util.HTML.attribs({
         'class': li_classes,
-        'data-subpost-id': post_id,
-        'style': li_style
+        'data-subpost-id': post_id
       });
     },
 


### PR DESCRIPTION
- Remove unnecessary browser prefixes
- Remove pink cast from result postbox
- Adjust size and padding of postbox
- Remove extra space above table of fields (since title is not currently supported)
- Remove inline styling from postbox
