### PR TITLE
Remove min-height from results area

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "description": "AddMany is a TacoWordPress add-on that allows you to create an arbitrary number of fields for custom posts in the WordPress admin",
   "license": "proprietary",
   "minimum-stability": "dev",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "require": {
     "php": ">= 5.4"
   },

--- a/src/Frontend/css/addmany.css
+++ b/src/Frontend/css/addmany.css
@@ -18,7 +18,6 @@
 .addmany-actual-values {
   clear: both;
   width: 100%;
-  min-height: 400px;
   height: auto;
   overflow-y: scroll;
 }


### PR DESCRIPTION
I don't know if you decided against this change, or if it was just overlooked when you were merging things manually, but I thought I'd try again.
